### PR TITLE
Update local port to match the book and fix bash condition in bin/exec

### DIFF
--- a/bin/exec
+++ b/bin/exec
@@ -8,7 +8,7 @@ if [ -z "$CMD" ]; then
   echo "😐 You should specify a command to run e.g. $0 ls -l"
   exit 1
 fi
-if [ "$CMD" == "help" ] || [ "$CMD" == "--help" ] || [ "$CMD" == "-h" ]; then
+if [ "$CMD" = "help" ] || [ "$CMD" = "--help" ] || [ "$CMD" = "-h" ]; then
   echo "USAGE"
   echo "  $0 command"
   echo

--- a/bin/vars
+++ b/bin/vars
@@ -2,7 +2,7 @@
 EXPOSE=3000
 # Set this to the port on your localhost you want to use to access
 # the EXPOSE port above
-LOCAL_PORT=9000
+LOCAL_PORT=9999
 # Set this to the tagname for the Docker image
 TAG=sustainable-rails-development
 


### PR DESCRIPTION
- The local port mentioned at many places in the book is 9999 but it was set to 9000 in bin/vars.
- The bash condition in bin/exec was using double equals (==) which is not working in `sh` but working with bash. I changed it to single quotes so that it works no matter what shell default language is used. My shell is zsh and it thought that this was sh and errored on the condition. You could also add `#!/bin/bash` at the top of the scripts if you want to let know any shell that this is bash not not sh and the double equals would then work.

Also, I've noticed on page 18 a small typo: 
> you likely have one _ore_ more

to
>you likely have one _or_ more

I didn't finish the book yet but so far it's awesome, thank you for sharing this great knowledge!