### PR TITLE
Update Dockerfile.template to use supported Ubuntu

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
 # This line says which base image we are building off of.
-# In this case, it's an Ubuntu 19.10 image running Linux
-FROM amd64/ubuntu:19.10
+# In this case, it's an Ubuntu 20.10 image running Linux
+FROM amd64/ubuntu:20.10
 
 # This sets the environment variable DEBIAN_FRONTEND that
 # all subsequent commands will see in their environments.


### PR DESCRIPTION
Hi David! I'm loving the book so far.

I had some trouble with setting up the local Docker container and was getting the following error output after running `bin/build`:

```
Ign:1 http://security.ubuntu.com/ubuntu eoan-security InRelease
Ign:2 http://archive.ubuntu.com/ubuntu eoan InRelease
Err:3 http://security.ubuntu.com/ubuntu eoan-security Release
  404  Not Found [IP: 91.189.88.152 80]
Ign:4 http://archive.ubuntu.com/ubuntu eoan-updates InRelease
Ign:5 http://archive.ubuntu.com/ubuntu eoan-backports InRelease
Err:6 http://archive.ubuntu.com/ubuntu eoan Release
  404  Not Found [IP: 91.189.88.142 80]
Err:7 http://archive.ubuntu.com/ubuntu eoan-updates Release
  404  Not Found [IP: 91.189.88.142 80]
Err:8 http://archive.ubuntu.com/ubuntu eoan-backports Release
  404  Not Found [IP: 91.189.88.142 80]
Reading package lists...
E: The repository 'http://security.ubuntu.com/ubuntu eoan-security Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu eoan Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu eoan-updates Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu eoan-backports Release' does not have a Release file.
```

Turns out, [Ubuntu 19.10 is EOL and no longer supported](https://wiki.ubuntu.com/Releases). I went ahead and upgraded to 20.10 which is the latest stable release.

Let me know if there are any other missing bits that I should take into account before you consider merging this. Thanks for writing the book! I'm excited to dig into the rest of it.